### PR TITLE
Call end write stream in updateStoreData and deleteStoreData

### DIFF
--- a/lib/njodb.js
+++ b/lib/njodb.js
@@ -475,7 +475,10 @@ const updateStoreData = async (store, match, update, tempstore, lockoptions) => 
         const handler = Handler("update", match, update);
 
         reader.on ("line", record => handler.next(record, writer));
-        reader.on ("close", () => resolve(handler.return()));
+        reader.on ("close", () => {
+            writer.end();
+            resolve(handler.return());
+        });
         reader.on("error", error => reject(error));
     });
 
@@ -539,7 +542,10 @@ const deleteStoreData = async (store, match, tempstore, lockoptions) => {
         const handler = Handler("delete", match);
 
         reader.on ("line", record => handler.next(record, writer));
-        reader.on ("close", () => resolve(handler.return()));
+        reader.on ("close", () => {
+            writer.end();
+            resolve(handler.return());
+        });
         reader.on("error", error => reject(error));
     });
 

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -220,7 +220,7 @@ const Handler = (type, ...functions) => {
 
                 if (type === "update" || type === "delete") {
                     if (writer) {
-                        writer.write(record.source) + "\n";
+                        writer.write(record.source + "\n");
                     } else {
                         _results.data.push(record.source);
                     }


### PR DESCRIPTION
Tldr; After the first update to the db, all other updates are failing. The `.old` file was not getting deleted due to the write stream staying open.

````javascript
// utils.js replaceFile
await promisify(rename)(a, a + ".old");  // <---- EPERM Error here on 2nd update.
await promisify(rename)(b, a);
await promisify(unlink)(a + ".old");    // <---- Successful on 1st update, but file is not actually removed
 ````

On Windows 10 using Node v12.19.0 an issue was occurring where the error
`Error: EPERM: operation not permitted, rename`
was being thrown on the second update.

The first update was successful, but it was not unlinking the last `.old` file. The `.old` file remained in the directory but could not be read or deleted until the nodejs process was closed. What was happening was the `.old` file still had an open file handler so when `unlink` was called Windows was "marking the file for deletion" and couldn't be accessed until the file handler was closed. [Explained here](https://stackoverflow.com/a/27277865/7431543)

After a lot of trial and error I found that the write stream in `updateStoreData` was never closing. This appears to be Windows specific, because I run njodb in linux with no issues. I think the best way to ensure the write stream gets closed is by calling the `.end()` method on the write stream when the read stream gets closed. Once the write stream is closed the `.old` file gets unlinked properly.

For testing I added `.on("close", ...)` listeners to the write stream with a few console logs and found that when calling `.end()` the write stream closed properly.

Also updated a small typo in `objects.js`