### PR TITLE
Catch temp file unlink

### DIFF
--- a/lib/njodb.js
+++ b/lib/njodb.js
@@ -484,7 +484,7 @@ const updateStoreData = async (store, match, update, tempstore, lockoptions) => 
     if (results.updated > 0) {
         await replaceFile(store, tempstore);
     } else {
-        await promisify(unlink)(tempstore);
+        await promisify(unlink)(tempstore).catch(() => { });
     }
 
     try {
@@ -548,7 +548,7 @@ const deleteStoreData = async (store, match, tempstore, lockoptions) => {
     if (results.deleted > 0) {
         await replaceFile(store, tempstore)
     } else {
-        await promisify(unlink)(tempstore);
+        await promisify(unlink)(tempstore).catch(() => { });
     }
 
     try {


### PR DESCRIPTION
A common issue I keep coming across on Windows is unlinking a temporary file that is no longer there.

Unlinking a file that does not exist throws an exception which results in the lock never getting released.

It may be useful to look into *why* the temp file is not there, but either way the exception should be caught.

```bash
[Error: ENOENT: no such file or directory, unlink 'C:\Users\Advplyr\myproject\mydata\tmp\data.4.json.1634855604579.tmp'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'unlink'
}
```