### PR TITLE
If replace file fails revert back to original

### DIFF
--- a/lib/njodb.js
+++ b/lib/njodb.js
@@ -485,7 +485,15 @@ const updateStoreData = async (store, match, update, tempstore, lockoptions) => 
     var results = Object.assign({store: resolve(store)}, handlerResults);
 
     if (results.updated > 0) {
-        await replaceFile(store, tempstore);
+        var success = await replaceFile(store, tempstore);
+        if (!success) {
+            try {
+                if (await check(store, lockoptions)) release();
+            } catch (error) {
+                console.error(error);
+            }
+            throw new Error('Update failed')
+        }
     } else {
         try {
             await promisify(unlink)(tempstore);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ const {
     rmdir,
     rmdirSync,
     unlink,
-    unlinkSync
+    unlinkSync,
 } = require("fs");
 
 const { promisify } = require("util");
@@ -74,7 +74,15 @@ const replaceFile = async (a, b) => {
     };
 
     await promisify(rename)(a, a + ".old");
-    await promisify(rename)(b, a);
+
+    try {
+        await promisify(rename)(b, a);
+    } catch(error) {
+        console.error('ReplaceFile Failed - Reverting back', error)
+        await promisify(rename)(a + ".old", a);
+        return false
+    }
+    
     await promisify(unlink)(a + ".old");
 
     results.replaced = true;


### PR DESCRIPTION
I still haven't pinned down why this is happening or when, but I had it happen again recently on linux.

I propose we add a safety fallback to `a.old`, so that if the rename fails during replaceFile we don't lose data.

You asked in #9 if the temp file was being created, I don't believe it is.

```js
// utils.js -> replaceFile

    await promisify(rename)(a, a + ".old");

    try {
        await promisify(rename)(b, a); // Error happening here, but I noticed that "a.old" is still there
    } catch(error) {
        console.error('ReplaceFile Failed - Reverting back', error)
        await promisify(rename)(a + ".old", a); // Revert back to prevent losing data
        return false
    }
    
    await promisify(unlink)(a + ".old");
```

I'd like it to throw an exception so I can keep an eye on it.